### PR TITLE
Move to GitHub actions

### DIFF
--- a/.github/workflows/gh-build.yaml
+++ b/.github/workflows/gh-build.yaml
@@ -1,0 +1,32 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main  # Set a branch to deploy
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          # extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.github/workflows/gh-build.yaml
+++ b/.github/workflows/gh-build.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/gh-build.yaml
+++ b/.github/workflows/gh-build.yaml
@@ -3,7 +3,8 @@ name: github pages
 on:
   push:
     branches:
-      - main  # Set a branch to deploy
+      - master
+      - move_to_github_actions #TODO remove
   pull_request:
 
 jobs:

--- a/.github/workflows/gh-build.yaml
+++ b/.github/workflows/gh-build.yaml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      # - master
       - move_to_github_actions #TODO remove
   pull_request:
 

--- a/.github/workflows/gh-build.yaml
+++ b/.github/workflows/gh-build.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: 'latest'
-          # extended: true
 
       - name: Build
         run: hugo --minify

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 public
+.hugo_build.lock

--- a/content/board/LoanVulliard.md
+++ b/content/board/LoanVulliard.md
@@ -1,6 +1,6 @@
 ---
 title: "Loan Vulliard"
-tagline: "Vice-president"
+tagline: "Vice president"
 date: 2021-01-12
 publishdate: 1970-01-01
 weight: 16

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,7 @@
     <title>{{ .Site.Title }}</title>
     <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
     <meta name="author" content="{{ with .Site.Params.author }}{{ . }}{{ end }}">
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     {{ partial "style.html" . }}
 </head>
 

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+cytodata.org

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-www.cytodata.org
+cytodata.org

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-cytodata.org
+www.cytodata.org


### PR DESCRIPTION
Change the hosting from Netlify to github page

This does NOT include 

2016.cytodata.org
2017.cytodata.org 
2018.cytodata.org 
2019.cytodata.org 

@shntnu what do you want to with past CytoData pages?
